### PR TITLE
Breaking changes in recent webpack versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,24 +77,24 @@
       "dev": true
     },
     "@types/tapable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.4.tgz",
-      "integrity": "sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
+      "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
-      "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
+      "integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
       }
     },
     "@types/webpack": {
-      "version": "4.39.8",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.39.8.tgz",
-      "integrity": "sha512-lkJvwNJQUPW2SbVwAZW9s9whJp02nzLf2yTNwMULa4LloED9MYS1aNnGeoBCifpAI1pEBkTpLhuyRmBnLEOZAA==",
+      "version": "4.41.22",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz",
+      "integrity": "sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==",
       "dev": true,
       "requires": {
         "@types/anymatch": "*",
@@ -106,14 +106,22 @@
       }
     },
     "@types/webpack-sources": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.5.tgz",
-      "integrity": "sha512-zfvjpp7jiafSmrzJ2/i3LqOyTYTuJ7u1KOXlKgDlvsj9Rr0x7ZiYu5lZbXwobL7lmsRNtPXlBfmaUD8eU2Hu8w==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.2.tgz",
+      "integrity": "sha512-77T++JyKow4BQB/m9O96n9d/UUHWLQHlcqXb9Vsf4F1+wKNrrlWNFPDLKNT92RJnCSL6CieTc+NDXtCVZswdTw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/source-list-map": "*",
-        "source-map": "^0.6.1"
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
       }
     },
     "ansi-colors": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/mocha": "5.2.7",
     "@types/node": "12.12.5",
     "@types/sinon": "7.5.0",
-    "@types/webpack": "4.39.8",
+    "@types/webpack": "4.41.22",
     "chai": "4.2.0",
     "mocha": "6.2.2",
     "rimraf": "3.0.0",
@@ -47,6 +47,6 @@
     "typescript": "3.6.4"
   },
   "peerDependencies": {
-    "webpack": "^4.41.2"
+    "webpack": "^4.42.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,8 +56,12 @@ export default class RunNodeWebpackPlugin {
                 return;
             }
 
-            const outputAssets = stats.compilation.assets;
+            const { compilation } = stats;
+            const { compiler } = compilation;
+            const outputAssets = compilation.assets;
+
             const outputAssetNames: string[] = Object.keys(outputAssets);
+            const outputPath = compilation.getPath(compiler.outputPath, {});
 
             // check if output assets dont exist. idk if this can really happen
             if (outputAssetNames.length < 1) {
@@ -103,7 +107,7 @@ export default class RunNodeWebpackPlugin {
                     // if it can not be found in webpack output then check if it exists in the file system
                     this.scriptName = findMatchingScriptName(this.options.scriptToRun, outputAssetNames);
                     if (this.scriptName) {
-                        this.scriptPath = outputAssets[this.scriptName].existsAt;
+                        this.scriptPath = compiler.outputFileSystem.join(outputPath, this.scriptName);
                     } else if (existsSync(this.options.scriptToRun)) {
                         this.scriptName = parse(this.options.scriptToRun).base;
                         this.scriptPath = normalize(this.options.scriptToRun);
@@ -124,14 +128,14 @@ export default class RunNodeWebpackPlugin {
                     if (outputAssetNames.length === 1) {
                         // if theres only 1 file in output assets choose it
                         this.scriptName = outputAssetNames[0];
-                        this.scriptPath = outputAssets[this.scriptName].existsAt;
+                        this.scriptPath = compiler.outputFileSystem.join(outputPath, this.scriptName);
                     } else {
                         // otherwise try to find scripts named 'server.js' or 'index.js'
                         this.scriptName =
                             findMatchingScriptName('server.js', outputAssetNames) ||
                             findMatchingScriptName('index.js', outputAssetNames);
                         if (this.scriptName) {
-                            this.scriptPath = outputAssets[this.scriptName].existsAt;
+                            this.scriptPath = compiler.outputFileSystem.join(outputPath, this.scriptName);
                         }
                     }
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,8 @@ export default class RunNodeWebpackPlugin {
             }
 
             const { compilation } = stats;
-            const { compiler } = compilation;
+            //  @ts-ignore
+            const { compiler, emittedAssets } = compilation;
             const outputAssets = compilation.assets;
 
             const outputAssetNames: string[] = Object.keys(outputAssets);
@@ -81,7 +82,7 @@ export default class RunNodeWebpackPlugin {
                     // if scriptsToWatch option is set then check if any of the given scripts changed
                     for (const scriptName of this.options.scriptsToWatch) {
                         const matchedName: string = findMatchingScriptName(scriptName, outputAssetNames);
-                        if (matchedName && outputAssets[matchedName].emitted) {
+                        if (matchedName && emittedAssets.has(matchedName)) {
                             shouldRun = true;
                             break;
                         }
@@ -89,7 +90,7 @@ export default class RunNodeWebpackPlugin {
                 } else {
                     // if scriptsToWatch option is NOT set then check if any of the output assets changed
                     for (const assetName of outputAssetNames) {
-                        if (outputAssets[assetName].emitted) {
+                        if (emittedAssets.has(assetName)) {
                             shouldRun = true;
                             break;
                         }


### PR DESCRIPTION
Thanks again for this package! I'm back with some changes, since we're in the process of switching our project to webpack 4.42. I've found that `run-node-webpack-plugin` isn't compatible with some of the changes that happened in webpack. I've taken a first stab at making the required changes.

1. `.existsAt` is no longer available for `outputAssets`. Instead, it's [recommended to concatenate the file path.](https://github.com/webpack/webpack/issues/8883).
2. `.emitted` is no longer available for `outputAssets`. I have not found a recommended alternative, but I did find `stats.compilation.emittedAssets`, which can be checked against. Unfortunately, it's not yet in the `@types` for webpack, so I've had to add a `@ts-ignore`. I'd be happy to make adjustments, if there's a better way to get this info.

How do you prefer to adjust the tests, since there will be new mocks required?